### PR TITLE
Add media dashboard example

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ npm install @ar-js-org/ar.js
 yarn add @ar-js-org/ar.js
 ```
 For some examples read this [issue](https://github.com/AR-js-org/AR.js/issues/234).
+You can also try the **Media Dashboard** example located at `aframe/examples/dashboard/index.html`
+to manage media files linked to markers or locations.
 ## Troubleshooting, feature requests, community
 
 **You can find a lot of help on the old [AR.js repositories issues](https://github.com/jeromeetienne/AR.js/issues). Please search on open/closed issues, you may find interesting stuff.**

--- a/aframe/examples/dashboard/dashboard.js
+++ b/aframe/examples/dashboard/dashboard.js
@@ -1,0 +1,136 @@
+(function() {
+  const tableBody = document.querySelector('#mediaTable tbody');
+  const formContainer = document.getElementById('formContainer');
+  const form = document.getElementById('mediaForm');
+  const formTitle = document.getElementById('formTitle');
+  const addButton = document.getElementById('addButton');
+  const cancelButton = document.getElementById('cancelButton');
+  const idField = document.getElementById('mediaId');
+  const nameField = document.getElementById('name');
+  const markerField = document.getElementById('marker');
+  const fileField = document.getElementById('file');
+
+  const STORAGE_KEY = 'arjsMedia';
+
+  function loadMedia() {
+    const data = localStorage.getItem(STORAGE_KEY);
+    return data ? JSON.parse(data) : [];
+  }
+
+  function saveMedia(list) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  }
+
+  function clearForm() {
+    idField.value = '';
+    nameField.value = '';
+    markerField.value = '';
+    fileField.value = '';
+  }
+
+  function renderTable() {
+    const media = loadMedia();
+    tableBody.innerHTML = '';
+    media.forEach(item => {
+      const tr = document.createElement('tr');
+      const previewTd = document.createElement('td');
+      if (item.type && item.src) {
+        if (item.type.startsWith('image')) {
+          const img = document.createElement('img');
+          img.src = item.src;
+          img.className = 'preview';
+          previewTd.appendChild(img);
+        } else if (item.type.startsWith('video')) {
+          const video = document.createElement('video');
+          video.src = item.src;
+          video.className = 'preview';
+          video.controls = true;
+          previewTd.appendChild(video);
+        }
+      }
+      tr.appendChild(previewTd);
+
+      const nameTd = document.createElement('td');
+      nameTd.textContent = item.name || '';
+      tr.appendChild(nameTd);
+
+      const markerTd = document.createElement('td');
+      markerTd.textContent = item.marker || '';
+      tr.appendChild(markerTd);
+
+      const actionTd = document.createElement('td');
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Edit';
+      editBtn.addEventListener('click', () => showForm(item));
+      const deleteBtn = document.createElement('button');
+      deleteBtn.textContent = 'Delete';
+      deleteBtn.addEventListener('click', () => {
+        const list = loadMedia().filter(m => m.id !== item.id);
+        saveMedia(list);
+        renderTable();
+      });
+      actionTd.appendChild(editBtn);
+      actionTd.appendChild(deleteBtn);
+      tr.appendChild(actionTd);
+
+      tableBody.appendChild(tr);
+    });
+  }
+
+  function showForm(item) {
+    formContainer.style.display = 'block';
+    if (item) {
+      formTitle.textContent = 'Edit Media';
+      idField.value = item.id;
+      nameField.value = item.name || '';
+      markerField.value = item.marker || '';
+    } else {
+      formTitle.textContent = 'Add Media';
+      clearForm();
+    }
+  }
+
+  function hideForm() {
+    formContainer.style.display = 'none';
+    clearForm();
+  }
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const list = loadMedia();
+    const id = idField.value || Date.now().toString();
+    const name = nameField.value.trim();
+    const marker = markerField.value.trim();
+    const file = fileField.files[0];
+    function finish(src, type) {
+      const existing = list.find(m => m.id === id);
+      if (existing) {
+        existing.name = name;
+        existing.marker = marker;
+        if (src) {
+          existing.src = src;
+          existing.type = type;
+        }
+      } else {
+        list.push({ id, name, marker, src, type });
+      }
+      saveMedia(list);
+      renderTable();
+      hideForm();
+    }
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = function(evt) {
+        finish(evt.target.result, file.type);
+      };
+      reader.readAsDataURL(file);
+    } else {
+      finish();
+    }
+  });
+
+  addButton.addEventListener('click', () => showForm());
+  cancelButton.addEventListener('click', hideForm);
+
+  renderTable();
+})();

--- a/aframe/examples/dashboard/index.html
+++ b/aframe/examples/dashboard/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>AR.js Media Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    #formContainer { border: 1px solid #ccc; padding: 10px; margin-top: 20px; }
+    .preview { max-height: 100px; }
+    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+    th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+    button { margin-right: 5px; }
+  </style>
+</head>
+<body>
+  <h1>Media Dashboard</h1>
+  <button id="addButton">Add Media</button>
+  <table id="mediaTable">
+    <thead>
+      <tr>
+        <th>Preview</th>
+        <th>Name</th>
+        <th>Marker/Location</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table>
+
+  <div id="formContainer" style="display:none;">
+    <h2 id="formTitle">Add Media</h2>
+    <form id="mediaForm">
+      <input type="hidden" id="mediaId">
+      <div>
+        <label>Name: <input type="text" id="name" required></label>
+      </div>
+      <div>
+        <label>Marker/Location: <input type="text" id="marker"></label>
+      </div>
+      <div>
+        <label>Media file: <input type="file" id="file" accept="image/*,video/*"></label>
+      </div>
+      <div style="margin-top:10px;">
+        <button type="submit">Save</button>
+        <button type="button" id="cancelButton">Cancel</button>
+      </div>
+    </form>
+  </div>
+
+  <script src="dashboard.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new example `aframe/examples/dashboard` for managing uploaded media
- allow adding, editing and deleting media with local storage
- document the dashboard example in the README

## Testing
- `npm test` *(fails: Error: no test specified)*