### PR TITLE
Add local static server

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,19 @@ Important! Be aware that if you are referring to external resources, in any app,
 If you cannot do that, you can host a proxy anywhere server to solve that (https://github.com/Rob--W/cors-anywhere).
 Please note that several hosting services have policies that does not permit to use such server. Always check hosting services policies before using them to avoid account suspensions
 
+
 Learn more on the [AR.js Official Documentation](https://ar-js-org.github.io/AR.js-Docs/).
+
+## Local static server
+
+You can quickly serve the repository files (including GLTF models and videos) using the provided static server.
+This adds the `Access-Control-Allow-Origin` header so assets can be loaded without CORS issues.
+
+```bash
+npm run serve
+```
+
+The server listens on port `8080` by default. Set the `PORT` environment variable to change it.
 
 ## ES6 npm package
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "./node_modules/.bin/webpack --mode=production",
     "build:dev": "./node_modules/.bin/webpack --mode=development --progress --watch",
     "server": "npx http-server -c -1",
+    "serve": "node static-server.js",
     "prepare": "husky install"
   },
   "files": [

--- a/static-server.js
+++ b/static-server.js
@@ -1,0 +1,58 @@
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname);
+const port = process.env.PORT || 8080;
+
+const mimeTypes = {
+  ".html": "text/html",
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".gltf": "model/gltf+json",
+  ".glb": "model/gltf-binary",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+};
+
+const server = http.createServer((req, res) => {
+  const requestPath = decodeURIComponent(req.url.split("?")[0]);
+  let filePath = path.join(root, requestPath);
+
+  if (!filePath.startsWith(root)) {
+    res.statusCode = 400;
+    res.end("Bad request");
+    return;
+  }
+
+  fs.stat(filePath, (err, stats) => {
+    if (!err && stats.isDirectory()) {
+      filePath = path.join(filePath, "index.html");
+    }
+
+    fs.readFile(filePath, (readErr, data) => {
+      if (readErr) {
+        res.writeHead(404, { "Access-Control-Allow-Origin": "*" });
+        res.end("Not found");
+        return;
+      }
+
+      const ext = path.extname(filePath).toLowerCase();
+      res.writeHead(200, {
+        "Content-Type": mimeTypes[ext] || "application/octet-stream",
+        "Access-Control-Allow-Origin": "*",
+      });
+      res.end(data);
+    });
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Static server running at http://localhost:${port}/`);
+});


### PR DESCRIPTION
## Summary
- add a simple Node static server for local testing with CORS enabled
- document how to run it in README
- expose an npm `serve` script

## Testing
- `npm test` *(fails: Error: no test specified)*